### PR TITLE
On standalone multi-seat systems, open only one root terminal per host.

### DIFF
--- a/epoptes/ui/gui.py
+++ b/epoptes/ui/gui.py
@@ -374,17 +374,26 @@ class EpoptesGui(object):
 
 
     ## FIXME / FIXUS: Should we allow it?
-    def openTerminal(self, em):
+    def openTerminal(self, em, one_per_host=False):
         clients = self.getSelectedClients()
         
         # If there is no client selected, send the command to all
         if len(clients) == 0:
             clients = self.cstore
 
+        addresses = []
+
         for client in clients:
             inst = client[C_INSTANCE]
             if inst.type == 'offline':
                 continue
+
+            if one_per_host:
+                host_address = client[C_SESSION_HANDLE].split(':')[0]
+                if host_address in addresses:
+                    continue
+                else:
+                    addresses.append(host_address)
 
             port = self.findUnusedPort()
             
@@ -404,7 +413,7 @@ class EpoptesGui(object):
 
 
     def openRootTerminal(self, widget):
-        self.openTerminal(EM_SYSTEM)
+        self.openTerminal(EM_SYSTEM, one_per_host=True)
 
 
     def remoteRootTerminal(self, widget):


### PR DESCRIPTION
On standalone multi-seat systems, there's no need to open a remote root terminal for each seat, since a single root terminal can have access to all seats on a given host (if graphical support is needed, one can set environment variable `DISPLAY` when spawning a command as root for that seat).

So we're proposing a patch to ensure that Epoptes will open a single root terminal per host address on standalone multi-seat systems, until it gains proper multi-seat support for system daemon. The changes proposed here should not affect use experience in other single-seat contexts (if it affects LTSP thin clients context, please let me know).