### PR TITLE
Fix for GUI being disconnected every time a user logs off under LXDE

### DIFF
--- a/epoptes/ui/notifications.py
+++ b/epoptes/ui/notifications.py
@@ -64,13 +64,16 @@ def cached_notify(title, body, icon):
     capability is not provided.
     """
     n = cache.get_notification(title)
-    if n:
-        n.close()
-        n.update(title, n.props.body+'\n'+body, icon)
-    else:
-        n = pynotify.Notification(title, body, icon)
-        cache.add_notification(n, title)
-    n.show()
+    try:
+        if n:
+            n.close()
+            n.update(title, n.props.body+'\n'+body, icon)
+        else:
+            n = pynotify.Notification(title, body, icon)
+            cache.add_notification(n, title)
+        n.show()
+    except:
+        print("Error showing notification. No notification server?")
 
 
 append = 'x-canonical-append' in pynotify.get_server_caps()


### PR DESCRIPTION
Some desktop environments such as LXDE do not have a notification
server running by default.

We should therefore be prepared that displaying notifications
can fail, and catch exceptions.

Otherwise exceptions like this are printed every time an attempt
is made to show a notification:

```
  **Twisted error: when connecting client 192.168.178.143:48968:
[Failure instance: Traceback: <class 'glib.GError'>: GDBus.Error:org.freedesktop.DBus.Error.ServiceUnknown:
The name org.freedesktop.Notifications was not provided by any .service files
/usr/lib/python2.7/dist-packages/twisted/protocols/amp.py:1063:ampBoxReceived
/usr/lib/python2.7/dist-packages/twisted/protocols/amp.py:991:_answerReceived
/usr/lib/python2.7/dist-packages/twisted/internet/defer.py:457:callback
/usr/lib/python2.7/dist-packages/twisted/internet/defer.py:565:_startRunCallbacks
--- <exception caught here> ---
/usr/lib/python2.7/dist-packages/twisted/internet/defer.py:651:_runCallbacks
/usr/lib/python2.7/dist-packages/epoptes/ui/gui.py:586:<lambda>
/usr/lib/python2.7/dist-packages/epoptes/ui/gui.py:764:addClient
/usr/lib/python2.7/dist-packages/epoptes/ui/notifications.py:86:loginNotify
/usr/lib/python2.7/dist-packages/epoptes/ui/notifications.py:73:cached_notify
```

And every time an user logged off, the Epoptes GUI lost connection to the
service as well, due to the exception generated when showing the notification
about the user logging off.

```
[GUI,0,] Amp server or network failure unhandled by client application.
Dropping connection!  To avoid, add errbacks to ALL remote commands!
```

https://github.com/raspberrypi/piserver/issues/8