### PR TITLE
Migrate Epoptes to Gtk3

### DIFF
--- a/epoptes-client/message
+++ b/epoptes-client/message
@@ -1,10 +1,10 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 ###########################################################################
-# Show a message using gtk.MessageDialog.
+# Display a simple window with a message.
 #
-# Copyright (C) 2012 Alkis Georgopoulos <alkisg@gmail.com>
+# Copyright (C) 2012-2018 Alkis Georgopoulos <alkisg@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -13,7 +13,7 @@
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FINESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
@@ -23,50 +23,55 @@
 # Public License can be found in `/usr/share/common-licenses/GPL".
 ############################################################################
 
-import gtk
+import gi
+gi.require_version('Gtk', '3.0')
+from gi.repository import Gtk
 
-def MessageDialog(text, title="Epoptes", markup=True, icon="dialog-information"):
-    if icon == "dialog-error":
-        type = gtk.MESSAGE_ERROR
-    elif icon == "dialog-question":
-        type = gtk.MESSAGE_QUESTION
-    elif icon == "dialog-warning":
-        type = gtk.MESSAGE_WARNING
-    else:
-        type = gtk.MESSAGE_INFO
-    dlg = gtk.MessageDialog(None, 0, type, gtk.BUTTONS_CLOSE, text)
-    dlg.set_modal(True)
-    dlg.set_title(title)
-    dlg.set_property('use-markup', markup)
-    dlg.set_property('skip-taskbar-hint', False)
-    dlg.set_property('icon-name', icon)
-    dlg.run()
-    dlg.destroy()
+
+class MessageWindow(Gtk.Window):
+
+    def __init__(self, text, title="Epoptes", markup=True, icon_name="dialog-information"):
+        Gtk.Window.__init__(self, title=title, icon_name=icon_name)
+
+        grid = Gtk.Grid(column_spacing=10, row_spacing=10, margin=10)
+        self.add(grid)
+
+        image = Gtk.Image.new_from_icon_name(icon_name, Gtk.IconSize.DIALOG)
+        grid.add(image)
+
+        # Always load the plain text first in case the markup parsing fails
+        label = Gtk.Label(
+            label=text, selectable=True, hexpand=True, vexpand=True, halign=Gtk.Align.START, valign=Gtk.Align.START)
+        if markup:
+            label.set_markup(text)
+        grid.add(label)
+
+        button = Gtk.Button.new_from_stock(Gtk.STOCK_CLOSE)
+        button.set_hexpand(False)
+        button.set_halign(Gtk.Align.END)
+        button.connect("clicked", Gtk.main_quit)
+        grid.attach(button, 1, 1, 2, 1)
+        self.set_focus_child(button)
+
+        accelgroup = Gtk.AccelGroup()
+        key, modifier = Gtk.accelerator_parse('Escape')
+        accelgroup.connect(key, modifier, Gtk.AccelFlags.VISIBLE, Gtk.main_quit)
+        self.add_accel_group(accelgroup)
 
 
 if __name__ == '__main__':
-    from sys import argv
+    from sys import argv, stderr
 
-    if not (len(argv) >= 1 and len(argv) <= 5):
-        print "Usage: message text [title] [markup] [icon]"
+    if len(argv) <= 1 or len(argv) > 5:
+        stderr.write("Usage: message text [title] [markup] [icon_name]\n")
         exit(1)
 
-    if len(argv) == 5:
-        type = argv[4]
-    else:
-        type = "dialog-information"
-
-    if len(argv) >= 4:
-        markup = argv[3] == "True"
-    else:
-        markup = "False"
-
-    if len(argv) >= 3:
-        title = argv[2]
-    else:
-        title = 'Epoptes'
-
-    if len(argv) >= 2:
-        text = argv[1]
-
-    MessageDialog(text, title, markup, type)
+    window = MessageWindow(
+        argv[1],
+        argv[2] if len(argv) > 2 else "Epoptes",
+        argv[3] == "True" if len(argv) > 3 else True,
+        argv[4] if len(argv) > 4 else "dialog-information"
+    )
+    window.connect("destroy", Gtk.main_quit)
+    window.show_all()
+    Gtk.main()

--- a/epoptes/ui/about_dialog.py
+++ b/epoptes/ui/about_dialog.py
@@ -5,6 +5,7 @@
 # About dialog.
 #
 # Copyright (C) 2010 Fotis Tsamis <ftsamis@gmail.com>
+# 2018, Alkis Georgopoulos <alkisg@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -23,26 +24,22 @@
 # Public License can be found in `/usr/share/common-licenses/GPL".
 ###########################################################################
 
-import gtk
-import pygtk
+import gi
+gi.require_version('Gtk', '3.0')
+from gi.repository import Gtk
 
 from epoptes import __version__
 
+
 class About:
     def __init__(self):
-        self.wTree = gtk.Builder()
+        self.wTree = Gtk.Builder()
         self.wTree.add_from_file('about_dialog.ui')
         self.wTree.connect_signals(self)
-        self.get = self.wTree.get_object
-        
-        self.dialog = self.get('aboutdialog')
-        logo = gtk.gdk.pixbuf_new_from_file_at_size(
-            '../icons/hicolor/scalable/apps/epoptes.svg', 64, 64)
-        self.dialog.set_logo(logo)
+
+        self.dialog = self.wTree.get_object('aboutdialog')
         self.dialog.set_version(__version__)
-        self.dialog.set_translator_credits(_("translator-credits"))
-        self.dialog.set_artists(["Andrew Wedderburn (application icon)"])
-    
+
     def run(self):
         self.dialog.run()
         self.dialog.destroy()

--- a/epoptes/ui/gtk/about_dialog.ui
+++ b/epoptes/ui/gtk/about_dialog.ui
@@ -1,42 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 -->
 <interface>
-  <requires lib="gtk+" version="2.16"/>
-  <!-- interface-naming-policy project-wide -->
+  <requires lib="gtk+" version="3.0"/>
   <object class="GtkAboutDialog" id="aboutdialog">
     <property name="can_focus">False</property>
-    <property name="border_width">5</property>
-    <property name="destroy_with_parent">True</property>
-    <property name="type_hint">normal</property>
-    <property name="skip_taskbar_hint">True</property>
+    <property name="type_hint">dialog</property>
     <property name="program_name">Epoptes</property>
-    <property name="copyright" translatable="yes">Copyright © 2011-2016 The Epoptes Team</property>
+    <property name="version">1.0</property>
+    <property name="copyright" translatable="yes">Copyright © 2011-2018 The Epoptes Team</property>
     <property name="comments" translatable="yes">A computer lab management and monitoring tool.</property>
     <property name="website">http://www.epoptes.org</property>
-    <property name="license" translatable="yes">Epoptes is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or any later version. 
-
-Epoptes is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details. 
-
-You should have received a copy of the GNU General Public License along with epoptes. If not, see &lt;http://www.gnu.org/licenses/&gt;.</property>
+    <property name="website_label">http://www.epoptes.org</property>
     <property name="authors">Alkis Georgopoulos &lt;alkisg@gmail.com&gt;
 Fotis Tsamis &lt;ftsamis@gmail.com&gt;</property>
-    <property name="wrap_license">True</property>
+    <property name="translator_credits" translatable="yes">translator-credits</property>
+    <property name="artists">Andrew Wedderburn (application icon)</property>
+    <property name="logo_icon_name">epoptes</property>
+    <property name="license_type">gpl-3-0</property>
+    <child>
+      <placeholder/>
+    </child>
     <child internal-child="vbox">
-      <object class="GtkVBox" id="dialog-vbox1">
-        <property name="visible">True</property>
+      <object class="GtkBox">
         <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
         <property name="spacing">2</property>
         <child internal-child="action_area">
-          <object class="GtkHButtonBox" id="dialog-action_area1">
-            <property name="visible">True</property>
+          <object class="GtkButtonBox">
             <property name="can_focus">False</property>
             <property name="layout_style">end</property>
           </object>
           <packing>
             <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="pack_type">end</property>
+            <property name="fill">False</property>
             <property name="position">0</property>
           </packing>
+        </child>
+        <child>
+          <placeholder/>
         </child>
       </object>
     </child>


### PR DESCRIPTION
This pull request is about migrating the rest of Epoptes to Gtk3, while still on Python2.
Starting now, and until this PR is ready for merging, Epoptes won't be runnable, as it's not possible to import Gtk3 python modules from Gtk2 modules.
Postponing the move to Python3 will hopefully allow us to run Epoptes again in a few weeks.
Also, this PR will only get minimal testing, while full testing will come after the Python3 migration.

## Pull request progress
Files migrated to Gtk3:
- about_dialog.py, about_dialog.ui

Files still using Gtk2:
- client_information.ui epoptes.ui executeCommand.ui netbenchmark.ui sendMessage.ui
- benchmark.py client_information.py execcommand.py graph.py gui.py notifications.py sendmessage.py