### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,6 @@ Maintainer: Epoptes Developers <epoptes@lists.launchpad.net>
 Uploaders: Vagrant Cascadian <vagrant@debian.org>, Alkis Georgopoulos <alkisg@gmail.com>
 Build-Depends: debhelper (>= 10),
  dh-python,
- dpkg-dev (>= 1.16.1),
  python3-distutils-extra,
  python3:any,
 Standards-Version: 4.5.1

--- a/debian/epoptes-client.maintscript
+++ b/debian/epoptes-client.maintscript
@@ -1,3 +1,0 @@
-rm_conffile /etc/init.d/epoptes-client 1.0.1-2~ epoptes-client
-rm_conffile /etc/init/epoptes-client.conf 1.0.1-2~ epoptes-client
-rm_conffile /etc/network/if-up.d/epoptes-client 1.0.1-2~ epoptes-client


### PR DESCRIPTION

Remove unnecessary constraints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/scrub-obsolete).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/scrub-obsolete.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/scrub-obsolete/pkg/epoptes/ba5902d4-d60a-4bb5-a144-b976d8ecad12.



## Debdiff

These changes affect the binary packages:


[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in second set of .debs but not in first
    -rw-r--r--  root/root   /usr/lib/python3/dist-packages/epoptes-22.01_1_jan_obs1.egg-info
### Files in first set of .debs but not in second
    -rw-r--r--  root/root   /usr/lib/python3/dist-packages/epoptes-22.01_1_jan_control1.egg-info

No differences were encountered between the control files of package \*\*epoptes\*\*

No differences were encountered between the control files of package \*\*epoptes-client\*\*


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/ba5902d4-d60a-4bb5-a144-b976d8ecad12/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/ba5902d4-d60a-4bb5-a144-b976d8ecad12/diffoscope)).
