### PR TITLE
epoptes/ui/gui.py: In the pipes module, pipes.quote() has for some time been pulled in from shlex.quote(), so import shlex directly and use quote() from there.

### DIFF
--- a/epoptes/ui/gui.py
+++ b/epoptes/ui/gui.py
@@ -7,7 +7,7 @@ Epoptes GUI class.
 """
 from distutils.version import LooseVersion
 import os
-import pipes
+import shlex
 import random
 import socket
 import string
@@ -1077,7 +1077,7 @@ class EpoptesGui(object):
         # ${GUI_PY} must be unquoted, don't pass it as list
         if isinstance(command, list) and len(command) > 0:
             command = '%s %s' % (command[0], ' '.join(
-                [pipes.quote(str(x)) for x in command[1:]]))
+                [shlex.quote(str(x)) for x in command[1:]]))
 
         if (clients != [] or handles != []) and warning != '':
             if not self.confirmation_dialog(warning):


### PR DESCRIPTION
Resolves: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1084716